### PR TITLE
bug/AKSIS-7-gns3-fix-static-routing-to-access-1_3_6_8-link

### DIFF
--- a/R1.txt
+++ b/R1.txt
@@ -26,4 +26,10 @@ ipv6 route ::/0 f0/0 FE80::7
 ipv6 route fd03:1:1:5::/64 e1/0 FE80::3
 ipv6 route fd03:1:1:2::/64 e1/0 FE80::3
 ipv6 route fd03:1:1:7::/64 e1/0 FE80::3
+
+
+ipv6 route fd03:1:1:6::/64 f0/0 FE80::7
+
+ipv6 route fd03:1:1:3::/64 e1/0 FE80::3
+
 end

--- a/R2.txt
+++ b/R2.txt
@@ -26,3 +26,9 @@ no shutdown
 exit
 
 ipv6 route ::/0 e1/0 FE80::5
+
+ipv6 route fd03:1:1:4::/64 e0/0 fe80::3
+ipv6 route fd03:1:1:a::/64 e0/0 fe80::3
+ipv6 route fd03:1:1:9::/64 e0/0 fe80::3
+
+end

--- a/R3.txt
+++ b/R3.txt
@@ -28,3 +28,4 @@ exit
 ipv6 route ::/0 e1/0 FE80::1
 ipv6 route fd03:1:1:2::/64 f0/0 FE80::5
 ipv6 route fd03:1:1:7::/64 f0/0 FE80::5
+end

--- a/R5.txt
+++ b/R5.txt
@@ -27,4 +27,6 @@ exit
 
 ipv6 route ::/0 f0/0 FE80::3
 ipv6 route fd03:1:1:7::/64 e1/0 FE80::2
+
+ipv6 route fd03:1:1:a::/64 e0/0 FE80::7
 end

--- a/R6.txt
+++ b/R6.txt
@@ -33,4 +33,9 @@ exit
 
 ipv6 route ::/0 f0/0 FE80::2
 
+ipv6 route fd03:1:1:a::/64 e1/0 fe80::7
+
+ipv6 route fd03:1:1:a::/64 e0/0 fe80::1
+ipv6 route fd03:1:1:9::/64 e0/0 fe80::1
+
 end

--- a/R7.txt
+++ b/R7.txt
@@ -30,4 +30,10 @@ ipv6 route fd03:1:1:4::/64 f0/0 FE80::1
 ipv6 route fd03:1:1:5::/64 f0/0 FE80::1
 ipv6 route fd03:1:1:2::/64 f0/0 FE80::1
 ipv6 route fd03:1:1:7::/64 f0/0 FE80::1
+
+ipv6 route fd03:1:1:6::/64 e0/0 FE80::8
+
+ipv6 route fd03:1:1:1::/64 f0/0 FE80::1
+ipv6 route fd03:1:1:3::/64 f0/0 FE80::1
+
 end

--- a/R8.txt
+++ b/R8.txt
@@ -39,4 +39,8 @@ ipv6 route fd03:1:1:4::/64 e0/0 FE80::7
 ipv6 route fd03:1:1:5::/64 e0/0 FE80::7
 ipv6 route fd03:1:1:2::/64 e0/0 FE80::7
 ipv6 route fd03:1:1:7::/64 e0/0 FE80::7
+
+ipv6 route fd03:1:1:3::/64 e0/0 FE80::7
+ipv6 route fd03:1:1:1::/64 e0/0 FE80::7
+ipv6 route fd03:1:1:8::/64 e0/0 FE80::7
 end


### PR DESCRIPTION
fixed by adding routes to 1 3 6 8 link which were not accessible by 8th 7th and 6th routers